### PR TITLE
Fix buffer overflow

### DIFF
--- a/bme68x.c
+++ b/bme68x.c
@@ -696,7 +696,7 @@ int8_t bme68x_get_heatr_conf(const struct bme68x_heatr_conf *conf, struct bme68x
     {
         if (conf && conf->heatr_dur_prof && conf->heatr_temp_prof)
         {
-            for (i = 0; i < 10; i++)
+            for (i = 0; i < conf->profile_len; i++)
             {
                 conf->heatr_temp_prof[i] = data_array[i];
             }
@@ -704,7 +704,7 @@ int8_t bme68x_get_heatr_conf(const struct bme68x_heatr_conf *conf, struct bme68x
             rslt = bme68x_get_regs(BME68X_REG_GAS_WAIT0, data_array, 10, dev);
             if (rslt == BME68X_OK)
             {
-                for (i = 0; i < 10; i++)
+                for (i = 0; i < conf->profile_len; i++)
                 {
                     conf->heatr_dur_prof[i] = data_array[i];
                 }

--- a/bme68x.c
+++ b/bme68x.c
@@ -289,10 +289,11 @@ int8_t bme68x_soft_reset(struct bme68x_dev *dev)
         {
             rslt = bme68x_set_regs(&reg_addr, &soft_rst_cmd, 1, dev);
 
-            /* Wait for 5ms */
-            dev->delay_us(BME68X_PERIOD_RESET, dev->intf_ptr);
             if (rslt == BME68X_OK)
             {
+                /* Wait for 5ms */
+                dev->delay_us(BME68X_PERIOD_RESET, dev->intf_ptr);
+
                 /* After reset get the memory page */
                 if (dev->intf == BME68X_SPI_INTF)
                 {

--- a/bme68x.c
+++ b/bme68x.c
@@ -747,7 +747,9 @@ int8_t bme68x_selftest_check(const struct bme68x_dev *dev)
     t_dev.amb_temp = 25;
     t_dev.read = dev->read;
     t_dev.write = dev->write;
+#if 0
     t_dev.intf = dev->intf;
+#endif
     t_dev.delay_us = dev->delay_us;
     t_dev.intf_ptr = dev->intf_ptr;
     rslt = bme68x_init(&t_dev);

--- a/bme68x.c
+++ b/bme68x.c
@@ -96,11 +96,13 @@ static int8_t read_field_data(uint8_t index, struct bme68x_data *data, struct bm
 /* This internal API is used to read all data fields of the sensor */
 static int8_t read_all_field_data(struct bme68x_data * const data[], struct bme68x_dev *dev);
 
+#if 0
 /* This internal API is used to switch between SPI memory pages */
 static int8_t set_mem_page(uint8_t reg_addr, struct bme68x_dev *dev);
 
 /* This internal API is used to get the current SPI memory page */
 static int8_t get_mem_page(struct bme68x_dev *dev);
+#endif
 
 /* This internal API is used to check the bme68x_dev for null pointers */
 static int8_t null_ptr_check(const struct bme68x_dev *dev);
@@ -192,6 +194,7 @@ int8_t bme68x_set_regs(const uint8_t *reg_addr, const uint8_t *reg_data, uint32_
             /* Interleave the 2 arrays */
             for (index = 0; index < len; index++)
             {
+#if 0
                 if (dev->intf == BME68X_SPI_INTF)
                 {
                     /* Set the memory page */
@@ -199,6 +202,7 @@ int8_t bme68x_set_regs(const uint8_t *reg_addr, const uint8_t *reg_data, uint32_
                     tmp_buff[(2 * index)] = reg_addr[index] & BME68X_SPI_WR_MSK;
                 }
                 else
+#endif
                 {
                     tmp_buff[(2 * index)] = reg_addr[index];
                 }
@@ -240,6 +244,7 @@ int8_t bme68x_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct
     rslt = null_ptr_check(dev);
     if ((rslt == BME68X_OK) && reg_data)
     {
+#if 0
         if (dev->intf == BME68X_SPI_INTF)
         {
             /* Set the memory page */
@@ -249,6 +254,7 @@ int8_t bme68x_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct
                 reg_addr = reg_addr | BME68X_SPI_RD_MSK;
             }
         }
+#endif
 
         dev->intf_rslt = dev->read(reg_addr, reg_data, len, dev->intf_ptr);
         if (dev->intf_rslt != 0)
@@ -279,10 +285,12 @@ int8_t bme68x_soft_reset(struct bme68x_dev *dev)
     rslt = null_ptr_check(dev);
     if (rslt == BME68X_OK)
     {
+#if 0
         if (dev->intf == BME68X_SPI_INTF)
         {
             rslt = get_mem_page(dev);
         }
+#endif
 
         /* Reset the device */
         if (rslt == BME68X_OK)
@@ -294,11 +302,13 @@ int8_t bme68x_soft_reset(struct bme68x_dev *dev)
                 /* Wait for 5ms */
                 dev->delay_us(BME68X_PERIOD_RESET, dev->intf_ptr);
 
+#if 0
                 /* After reset get the memory page */
                 if (dev->intf == BME68X_SPI_INTF)
                 {
                     rslt = get_mem_page(dev);
                 }
+#endif
             }
         }
     }
@@ -1355,6 +1365,7 @@ static int8_t read_all_field_data(struct bme68x_data * const data[], struct bme6
     return rslt;
 }
 
+#if 0
 /* This internal API is used to switch between SPI memory pages */
 static int8_t set_mem_page(uint8_t reg_addr, struct bme68x_dev *dev)
 {
@@ -1423,6 +1434,7 @@ static int8_t get_mem_page(struct bme68x_dev *dev)
 
     return rslt;
 }
+#endif
 
 /* This internal API is used to limit the max value of a parameter */
 static int8_t boundary_check(uint8_t *value, uint8_t max, struct bme68x_dev *dev)

--- a/bme68x_defs.h
+++ b/bme68x_defs.h
@@ -704,8 +704,10 @@ typedef void (*bme68x_delay_us_fptr_t)(uint32_t period, void *intf_ptr);
  * @brief Interface selection Enumerations
  */
 enum bme68x_intf {
+#if 0
     /*! SPI interface */
     BME68X_SPI_INTF,
+#endif
     /*! I2C interface */
     BME68X_I2C_INTF
 };
@@ -943,8 +945,10 @@ struct bme68x_dev
     /*! SPI/I2C interface */
     enum bme68x_intf intf;
 
+#if 0
     /*! Memory page used */
     uint8_t mem_page;
+#endif
 
     /*! Ambient temperature in Degree C*/
     int8_t amb_temp;

--- a/bme68x_defs.h
+++ b/bme68x_defs.h
@@ -772,11 +772,48 @@ struct bme68x_data
  */
 struct bme68x_calib_data
 {
+#ifndef BME68X_USE_FPU
+
+    /*! Variable to store the intermediate temperature coefficient */
+    int32_t t_fine;
+#else
+
+    /*! Variable to store the intermediate temperature coefficient */
+    float t_fine;
+#endif
+
     /*! Calibration coefficient for the humidity sensor */
     uint16_t par_h1;
 
     /*! Calibration coefficient for the humidity sensor */
     uint16_t par_h2;
+
+    /*! Calibration coefficient for the gas sensor */
+    int16_t par_gh2;
+
+    /*! Calibration coefficient for the temperature sensor */
+    uint16_t par_t1;
+
+    /*! Calibration coefficient for the temperature sensor */
+    int16_t par_t2;
+
+    /*! Calibration coefficient for the pressure sensor */
+    uint16_t par_p1;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t par_p2;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t par_p4;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t par_p5;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t par_p8;
+
+    /*! Calibration coefficient for the pressure sensor */
+    int16_t par_p9;
 
     /*! Calibration coefficient for the humidity sensor */
     int8_t par_h3;
@@ -797,34 +834,13 @@ struct bme68x_calib_data
     int8_t par_gh1;
 
     /*! Calibration coefficient for the gas sensor */
-    int16_t par_gh2;
-
-    /*! Calibration coefficient for the gas sensor */
     int8_t par_gh3;
-
-    /*! Calibration coefficient for the temperature sensor */
-    uint16_t par_t1;
-
-    /*! Calibration coefficient for the temperature sensor */
-    int16_t par_t2;
 
     /*! Calibration coefficient for the temperature sensor */
     int8_t par_t3;
 
     /*! Calibration coefficient for the pressure sensor */
-    uint16_t par_p1;
-
-    /*! Calibration coefficient for the pressure sensor */
-    int16_t par_p2;
-
-    /*! Calibration coefficient for the pressure sensor */
     int8_t par_p3;
-
-    /*! Calibration coefficient for the pressure sensor */
-    int16_t par_p4;
-
-    /*! Calibration coefficient for the pressure sensor */
-    int16_t par_p5;
 
     /*! Calibration coefficient for the pressure sensor */
     int8_t par_p6;
@@ -833,22 +849,7 @@ struct bme68x_calib_data
     int8_t par_p7;
 
     /*! Calibration coefficient for the pressure sensor */
-    int16_t par_p8;
-
-    /*! Calibration coefficient for the pressure sensor */
-    int16_t par_p9;
-
-    /*! Calibration coefficient for the pressure sensor */
     uint8_t par_p10;
-#ifndef BME68X_USE_FPU
-
-    /*! Variable to store the intermediate temperature coefficient */
-    int32_t t_fine;
-#else
-
-    /*! Variable to store the intermediate temperature coefficient */
-    float t_fine;
-#endif
 
     /*! Heater resistance range coefficient */
     uint8_t res_heat_range;
@@ -920,9 +921,6 @@ struct bme68x_heatr_conf
  */
 struct bme68x_dev
 {
-    /*! Chip Id */
-    uint8_t chip_id;
-
     /*!
      * The interface pointer is used to enable the user
      * to link their interface descriptors for reference during the
@@ -930,6 +928,29 @@ struct bme68x_dev
      * hardware.
      */
     void *intf_ptr;
+
+    /*! Read function pointer */
+    bme68x_read_fptr_t read;
+
+    /*! Write function pointer */
+    bme68x_write_fptr_t write;
+
+    /*! Delay function pointer */
+    bme68x_delay_us_fptr_t delay_us;
+
+    /*! Sensor calibration data */
+    struct bme68x_calib_data calib;
+
+#if 0
+    /*! SPI/I2C interface */
+    enum bme68x_intf intf;
+
+    /*! Memory page used */
+    uint8_t mem_page;
+#endif
+
+    /*! Chip Id */
+    uint8_t chip_id;
 
     /*!
      *             Variant id
@@ -940,30 +961,10 @@ struct bme68x_dev
      *      1      |   BME68X_VARIANT_GAS_HIGH
      * ----------------------------------------
      */
-    uint32_t variant_id;
-
-    /*! SPI/I2C interface */
-    enum bme68x_intf intf;
-
-#if 0
-    /*! Memory page used */
-    uint8_t mem_page;
-#endif
+    uint8_t variant_id;
 
     /*! Ambient temperature in Degree C*/
     int8_t amb_temp;
-
-    /*! Sensor calibration data */
-    struct bme68x_calib_data calib;
-
-    /*! Read function pointer */
-    bme68x_read_fptr_t read;
-
-    /*! Write function pointer */
-    bme68x_write_fptr_t write;
-
-    /*! Delay function pointer */
-    bme68x_delay_us_fptr_t delay_us;
 
     /*! To store interface pointer error */
     BME68X_INTF_RET_TYPE intf_rslt;


### PR DESCRIPTION
Continue to read out the full 10 values but only copy to caller buffer what the caller supplied space for.