### PR TITLE
Fixed comment of float humidity

### DIFF
--- a/bme68x_defs.h
+++ b/bme68x_defs.h
@@ -755,7 +755,7 @@ struct bme68x_data
     /*! Pressure in Pascal */
     float pressure;
 
-    /*! Humidity in % relative humidity x1000 */
+    /*! Humidity in % relative humidity */
     float humidity;
 
     /*! Gas resistance in Ohms */


### PR DESCRIPTION
# Overview
The comment for humidity of type float was written as x1000 even though the value was not multiplied by 1000, so the comment has been corrected to prevent confusion.

# Basis
- As shown in the example code below, the value of humidity is not divided by 1000 when FPU is not used.
https://github.com/boschsensortec/BME68x-Sensor-API/blob/80ea120a8b8ac987d7d79eb68a9ed796736be845/examples/forced_mode/forced_mode.c#L82-L100
- Because in the uint32_t calc_humidity method, calc_hum is capped at 100000, but in the float calc_humidity method, calc_hum is capped at 100.0f.
https://github.com/boschsensortec/BME68x-Sensor-API/blob/80ea120a8b8ac987d7d79eb68a9ed796736be845/bme68x.c#L927-L938
https://github.com/boschsensortec/BME68x-Sensor-API/blob/80ea120a8b8ac987d7d79eb68a9ed796736be845/bme68x.c#L1093-L1103